### PR TITLE
Rename class

### DIFF
--- a/Sources/FileSystemOperations.swift
+++ b/Sources/FileSystemOperations.swift
@@ -54,7 +54,7 @@ class FileSystemOperationsImplemetation: FileSystemOperations {
 
 // MARK: - Mock Implementation
 
-class MockFileSystemOperations: FileSystemOperations {
+class FileSystemOperationsMock: FileSystemOperations {
     var files: [String: String] = [:]
     var enumeratorPaths: [String] = []
     var directories: Set<String> = []

--- a/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
+++ b/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
@@ -11,13 +11,13 @@ import XCTest
 @testable import SwiftFilesCombiner
 
 class SwiftFilesCombinerTests: XCTestCase {
-    var mockFileSystem: MockFileSystemOperations!
+    var mockFileSystem: FileSystemOperationsMock!
     let baseDir = "/test"
     let outputFile = "/test/output.swift"
 
     override func setUp() {
         super.setUp()
-        mockFileSystem = MockFileSystemOperations()
+        mockFileSystem = FileSystemOperationsMock()
         mockFileSystem.directories.insert(baseDir)
     }
 

--- a/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
+++ b/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
@@ -19,6 +19,7 @@ class SwiftFilesCombinerTests: XCTestCase {
         super.setUp()
         mockFileSystem = FileSystemOperationsMock()
         mockFileSystem.directories.insert(baseDir)
+        mockFileSystem.enumeratorPaths = []
     }
 
     func testOnlyNonSwiftFiles() throws {
@@ -125,9 +126,6 @@ class SwiftFilesCombinerTests: XCTestCase {
     }
 
     func testExistingEmptyDirectory() throws {
-        mockFileSystem.directories.insert(baseDir)
-        mockFileSystem.enumeratorPaths = []
-        
         XCTAssertNoThrow(try combineSwiftFiles(in: baseDir, outputFile: outputFile, fileSystem: mockFileSystem))
         
         XCTAssertTrue(mockFileSystem.fileExists(atPath: outputFile))

--- a/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
+++ b/Tests/SwiftFilesCombinerTests/SwiftFilesCombinerTests.swift
@@ -21,14 +21,6 @@ class SwiftFilesCombinerTests: XCTestCase {
         mockFileSystem.directories.insert(baseDir)
     }
 
-    func testEmptyDirectory() throws {
-        try combineSwiftFiles(in: baseDir, outputFile: outputFile, fileSystem: mockFileSystem)
-        
-        XCTAssertTrue(mockFileSystem.fileExists(atPath: outputFile))
-        let output = try mockFileSystem.contentsOfFile(atPath: outputFile)
-        XCTAssertTrue(output.isEmpty)
-    }
-
     func testOnlyNonSwiftFiles() throws {
         mockFileSystem.files = [
             "\(baseDir)/file1.txt": "Not a Swift file",


### PR DESCRIPTION
Rename for consistency:

```
FileSystemOperations
FileSystemOperationsImplemetation
FileSystemOperationsMock
```

